### PR TITLE
require test codes to prevent reference error on main codes

### DIFF
--- a/lib/chanko_ab.rb
+++ b/lib/chanko_ab.rb
@@ -1,4 +1,5 @@
 require "chanko_ab/version"
+require "chanko_ab/test"
 require "chanko_ab/split_test"
 require "chanko_ab/logic/base"
 require "chanko_ab/logic/number_identifier"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'rubygems'
 require 'chanko'
 require 'chanko_ab'
-require "chanko_ab/test"
 
 class Chanko::Loader
   def add_autoload_path
@@ -17,7 +16,7 @@ class ChankoAdoptedClass
   end
 
   def request
-    { }
+    {}
   end
 end
 


### PR DESCRIPTION
Since the test code is not separated from the main code, constant reference errors can occur in production in the future.