### PR TITLE
no more implicit context and ab process

### DIFF
--- a/lib/chanko_ab/split_test.rb
+++ b/lib/chanko_ab/split_test.rb
@@ -78,7 +78,7 @@ module ChankoAb
           function(key) do
             __split_test__.process(self, request, identifier) do |process|
               next run_default if process.should_run_default?
-              self.instance_eval(&block)
+              block.call(self, process)
             end
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,11 +28,11 @@ module ChankoAbExperiment
   active_if { true }
 
   split_test.log_template('my_log' ,'my_log.[name]')
-  split_test.define(:name, scope: ChankoAdoptedClass) do
+  split_test.define(:name, scope: ChankoAdoptedClass) do |context, ab|
     ab.name
   end
 
-  split_test.define(:log, scope: ChankoAdoptedClass) do
+  split_test.define(:log, scope: ChankoAdoptedClass) do |context, ab|
     ab.log('my_log')
   end
 end


### PR DESCRIPTION
before
```
split_test.define(:xxx) do
end
```

after
```
split_test.define(:xxx) do |context, ab|
end
```